### PR TITLE
Fix encoding issue with degree symbol

### DIFF
--- a/front-end/src/Main.elm
+++ b/front-end/src/Main.elm
@@ -285,7 +285,7 @@ footerLocation model =
                 a [href ("https://www.google.com/maps?q="
                         ++ String.fromFloat loc.latitude ++ ","
                         ++ String.fromFloat loc.longitude)]
-                  [text <| lat ++ "°N " ++ lon ++ "°W"],
+                  [text <| lat ++ "\u{00B0}N " ++ lon ++ "\u{00B0}W"],
                 text " | "])
 
 windowClosing : Model -> String


### PR DESCRIPTION
On my browser, the unicode literal in the file text was getting mangled, possibly due to changes in interpreting the file encoding. Removing the unicode character and inserting the literal `\u{}` value for the symbol should resolve this issue.